### PR TITLE
Include targetingKey in Java EvaluationContext

### DIFF
--- a/openfeature/provider-java/src/main/scala/io/cardell/openfeature/provider/java/JavaConverters.scala
+++ b/openfeature/provider-java/src/main/scala/io/cardell/openfeature/provider/java/JavaConverters.scala
@@ -66,7 +66,7 @@ object ToJavaConverters {
 
   def evaluationContext(ec: EvaluationContext): JContext = {
     val values = ec.values.map { case (k, v) => (k, contextValue(v)) }.asJava
-    new JContext(values)
+    ec.targetingKey.fold(new JContext(values))(tk => new JContext(tk, values))
   }
 
   def structure(structure: Structure): JStructure = {


### PR DESCRIPTION
When converting to the Java SDK's EvaluationContext, the targetingKey would get lost which leads to wrong evaluations or even failures when using it with Go Feature Flag. Passing the targetingKey explicitly based on its presence fixes this.